### PR TITLE
old session list of XCamp

### DIFF
--- a/_posts/2017-11-09-brant-cooper-keynote-und-jede-menge-toller-speaker-und-sessions.md
+++ b/_posts/2017-11-09-brant-cooper-keynote-und-jede-menge-toller-speaker-und-sessions.md
@@ -1,7 +1,7 @@
 ---
 layout:     post
 title:      Brant Cooper Keynote und jede Menge toller Speaker und Sessions
-authorPage: Christiane Gerigk
+authorPage: christiane-gerigk
 published:  09.11.2017
 image:      media/BRANT-COOPER-CEO-AND-CO-FOUNDER-Movies-the-needle-320x202.jpg
 tags:       XCamp2017, Sessions
@@ -10,55 +10,55 @@ tags:       XCamp2017, Sessions
 Wahnsinn – welche Themenvielvalt in der Sessionplanung des #XCamp17 ist:
 
 ##Keynote: 5 Startup Myths That Will Destroy Your Company
-– ![Brant Cooper](https://www.brantcooper.com/), Author of The Lean Entrepreneur, CEO Moves the Needle Inc.
+– [Brant Cooper](https://www.brantcooper.com/), Author of The Lean Entrepreneur, CEO Moves the Needle Inc.
 
 ##Ausgerechnet die DB Systel! Aus der Praxis einer agilen Transformation
 
-– ![Martin Strunk, DB Systel GmbH](https://www.xing.com/profile/Martin_Strunk/cv)
+– [Martin Strunk, DB Systel GmbH](https://www.xing.com/profile/Martin_Strunk/cv)
 
 ##Google Design Sprint
 
-– ![Benno Löwenberg](https://loewenberg.info/)
+– [Benno Löwenberg](https://loewenberg.info/)
 
 ##Das Personalressort der R+V als Innovations-Promotor
 
-– ![André Dörfler, R+V Versicherung](https://www.xing.com/profile/Andre_Doerfler/cv)
+– [André Dörfler, R+V Versicherung](https://www.xing.com/profile/Andre_Doerfler/cv)
 
 ##Wir haben das schon immer anders gemacht!
 Lean Startup Methoden in der Unternehmenswirklichkeit
-– ![Marc Frey, Simplify Innovators](https://www.xing.com/profile/Marc_Frey)
+– [Marc Frey, Simplify Innovators](https://www.xing.com/profile/Marc_Frey)
 
 ##Software, die Mitarbeiter nutzen wollen und nicht sollen
-– ![Nicolas Scheel](https://www.xing.com/contacts/recommendations)
+– [Nicolas Scheel](https://www.xing.com/contacts/recommendations)
 
 ##“Management 3.0 – Kultur(r-)evolution – Freiheit – Freiräume – mehr Verantwortung @DB Systel”
- – ![Marion Seitz, DB Systel](https://www.xing.com/profile/Marion_Seitz9/cv)
+ – [Marion Seitz, DB Systel](https://www.xing.com/profile/Marion_Seitz9/cv)
 
 ##Von der Ursache geile Geschichten zu erzählen bis zur Umsetzung
-– ![Torsten J. Koerting, The Game Changer](https://www.xing.com/profile/Torsten_Koerting/portfolio)
+– [Torsten J. Koerting, The Game Changer](https://www.xing.com/profile/Torsten_Koerting/portfolio)
 
 ##Es geht doch anders! Erfahrungen bei der Einführung von agilen Prozessen
-– ![Andrea Heisel](https://www.xing.com/profile/Andrea_Heisel/cv) und ![Soete Klien](https://www.xing.com/profile/Soete_Klien/cv), 
+– [Andrea Heisel](https://www.xing.com/profile/Andrea_Heisel/cv) und ![Soete Klien](https://www.xing.com/profile/Soete_Klien/cv), 
 GIZ – Deutsche Gesellschaft für Internationale Zusammenarbeit
 
 ##Lean UX – mehr Kundenzentrierung und Innovation in klassischen agile Prozessen
-– ![Wolf Nöding](http://wolfnoeding.de/)
+– [Wolf Nöding](http://wolfnoeding.de/)
 
 ##„Innovation Circle“: Mitarbeiter-zentrierte Innovationsmodelle fördern
-– ![Julian Hofmann von Etecture GmbH](https://www.etecture.de/)
+– [Julian Hofmann von Etecture GmbH](https://www.etecture.de/)
 
 ##Story Telling, Metaphern und Modelle: Eine kreative Retrospektive unter Verwendung von LEGO®-Materialien (Hands-on Workshop)
-– ![Britta Ollrogge](https://www.britta-ollrogge-consulting.de/)
+– [Britta Ollrogge](https://www.britta-ollrogge-consulting.de/)
 
 ##Bitte recht empathisch!
-– ![Jane Schek](http://www.jane-schek.de/)
+– [Jane Schek](http://www.jane-schek.de/)
 
 ##Manage frei für agiles Arbeiten in der Deutschen Gesellschaft für Internationale Zusammenarbeit (GIZ) – Innen-, Ein- sowie Aussichten eines Experiments –
 Andrea Heisel und Soete Klien, GIZ
 Zudem wird es drei Workshop-Sessions geben zum Einstieg in die Methoden
 
 ##Einführungs-Workshop in die Design Thinking Praxis
-– ![Jens Bothmer, Autentity](https://www.autentity.de/ueber-autentity-business-innovation/profil-jens-bothmer/)
+– [Jens Bothmer, Autentity](https://www.autentity.de/ueber-autentity-business-innovation/profil-jens-bothmer/)
 
 ##Lean Startup –
 
@@ -66,13 +66,13 @@ Norbert Lang, Creative Learning Space
 
 ##SCRUM. Agile Entwicklungsprinzipien
 
-– ![Christiane Gerigk](https://digital-wachsen.de/)
+– [Christiane Gerigk](https://digital-wachsen.de/)
 
-Voller Vorfreude
-Euer XCamp-Team
+Voller Vorfreude<br>
+Euer XCamp-Team<br>
 
-Christiane Gerigk
-Jens Bothmer
-Stefan Trost
-Bianca Köllner
-Albert Schliemann
+Christiane Gerigk<br>
+Jens Bothmer<br>
+Stefan Trost<br>
+Bianca Köllner<br>
+Albert Schliemann<br>

--- a/_posts/2017-11-09-brant-cooper-keynote-und-jede-menge-toller-speaker-und-sessions.md
+++ b/_posts/2017-11-09-brant-cooper-keynote-und-jede-menge-toller-speaker-und-sessions.md
@@ -1,0 +1,78 @@
+---
+layout:     post
+title:      Brant Cooper Keynote und jede Menge toller Speaker und Sessions
+authorPage: Christiane Gerigk
+published:  09.11.2017
+image:      media/BRANT-COOPER-CEO-AND-CO-FOUNDER-Movies-the-needle-320x202.jpg
+tags:       XCamp2017, Sessions
+---
+
+Wahnsinn – welche Themenvielvalt in der Sessionplanung des #XCamp17 ist:
+
+##Keynote: 5 Startup Myths That Will Destroy Your Company
+– ![Brant Cooper](https://www.brantcooper.com/), Author of The Lean Entrepreneur, CEO Moves the Needle Inc.
+
+##Ausgerechnet die DB Systel! Aus der Praxis einer agilen Transformation
+
+– ![Martin Strunk, DB Systel GmbH](https://www.xing.com/profile/Martin_Strunk/cv)
+
+##Google Design Sprint
+
+– ![Benno Löwenberg](https://loewenberg.info/)
+
+##Das Personalressort der R+V als Innovations-Promotor
+
+– ![André Dörfler, R+V Versicherung](https://www.xing.com/profile/Andre_Doerfler/cv)
+
+##Wir haben das schon immer anders gemacht!
+Lean Startup Methoden in der Unternehmenswirklichkeit
+– ![Marc Frey, Simplify Innovators](https://www.xing.com/profile/Marc_Frey)
+
+##Software, die Mitarbeiter nutzen wollen und nicht sollen
+– ![Nicolas Scheel](https://www.xing.com/contacts/recommendations)
+
+##“Management 3.0 – Kultur(r-)evolution – Freiheit – Freiräume – mehr Verantwortung @DB Systel”
+ – ![Marion Seitz, DB Systel](https://www.xing.com/profile/Marion_Seitz9/cv)
+
+##Von der Ursache geile Geschichten zu erzählen bis zur Umsetzung
+– ![Torsten J. Koerting, The Game Changer](https://www.xing.com/profile/Torsten_Koerting/portfolio)
+
+##Es geht doch anders! Erfahrungen bei der Einführung von agilen Prozessen
+– ![Andrea Heisel](https://www.xing.com/profile/Andrea_Heisel/cv) und ![Soete Klien](https://www.xing.com/profile/Soete_Klien/cv), 
+GIZ – Deutsche Gesellschaft für Internationale Zusammenarbeit
+
+##Lean UX – mehr Kundenzentrierung und Innovation in klassischen agile Prozessen
+– ![Wolf Nöding](http://wolfnoeding.de/)
+
+##„Innovation Circle“: Mitarbeiter-zentrierte Innovationsmodelle fördern
+– ![Julian Hofmann von Etecture GmbH](https://www.etecture.de/)
+
+##Story Telling, Metaphern und Modelle: Eine kreative Retrospektive unter Verwendung von LEGO®-Materialien (Hands-on Workshop)
+– ![Britta Ollrogge](https://www.britta-ollrogge-consulting.de/)
+
+##Bitte recht empathisch!
+– ![Jane Schek](http://www.jane-schek.de/)
+
+##Manage frei für agiles Arbeiten in der Deutschen Gesellschaft für Internationale Zusammenarbeit (GIZ) – Innen-, Ein- sowie Aussichten eines Experiments –
+Andrea Heisel und Soete Klien, GIZ
+Zudem wird es drei Workshop-Sessions geben zum Einstieg in die Methoden
+
+##Einführungs-Workshop in die Design Thinking Praxis
+– ![Jens Bothmer, Autentity](https://www.autentity.de/ueber-autentity-business-innovation/profil-jens-bothmer/)
+
+##Lean Startup –
+
+Norbert Lang, Creative Learning Space
+
+##SCRUM. Agile Entwicklungsprinzipien
+
+– ![Christiane Gerigk](https://digital-wachsen.de/)
+
+Voller Vorfreude
+Euer XCamp-Team
+
+Christiane Gerigk
+Jens Bothmer
+Stefan Trost
+Bianca Köllner
+Albert Schliemann


### PR DESCRIPTION
- Lean Startup was linked in old blogpost, I left this link here away, because it didn't work. It might not be so relevant. 
- It looks like Wolfs webpage is down at the moment - hope just temporally. 
- All other sessions are linked to to Xing etc pages, but Brand Coopers name didn't have a link in original - so I added link to his webpage.